### PR TITLE
Uniform Paths Feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,6 +82,7 @@
 //! # }
 //! ```
 #![deny(warnings)]
+#![feature(uniform_paths)]
 #![warn(missing_docs)]
 #[macro_use]
 extern crate serde_derive;


### PR DESCRIPTION
When building on `rustc 1.32.0-nightly (d09466ceb 2018-11-30)` I run into the following problem

```
error[E0658]: imports can only refer to extern crate names passed with `--extern` on stable channel (see issue #53130)
   --> src/lib.rs:542:9
    |
539 | mod diff;
    | --------- not an extern crate passed with `--extern`
...
542 | pub use diff::diff;
    |         ^^^^
    |
    = help: add #![feature(uniform_paths)] to the crate attributes to enable
note: this import refers to the module defined here
   --> src/lib.rs:539:1
    |
539 | mod diff;
    | ^^^^^^^^^

error[E0658]: imports can only refer to extern crate names passed with `--extern` on stable channel (see issue #53130)
   --> src/lib.rs:190:13
    |
180 | / pub enum PatchError {
181 | |     /// One of the pointers in the patch is invalid
182 | |     InvalidPointer,
183 | |
184 | |     /// 'test' operation failed
185 | |     TestFailed,
186 | | }
    | |_- not an extern crate passed with `--extern`
...
190 |           use PatchError::*;
    |               ^^^^^^^^^^
    |
    = help: add #![feature(uniform_paths)] to the crate attributes to enable
note: this import refers to the enum defined here
   --> src/lib.rs:180:1
    |
180 | / pub enum PatchError {
181 | |     /// One of the pointers in the patch is invalid
182 | |     InvalidPointer,
183 | |
184 | |     /// 'test' operation failed
185 | |     TestFailed,
186 | | }
    | |_^

error[E0658]: imports can only refer to extern crate names passed with `--extern` on stable channel (see issue #53130)
   --> src/lib.rs:391:9
    |
163 | / pub enum PatchOperation {
164 | |     /// 'add' operation
165 | |     Add(AddOperation),
166 | |     /// 'remove' operation
...   |
175 | |     Test(TestOperation),
176 | | }
    | |_- not an extern crate passed with `--extern`
...
391 |       use PatchOperation::*;
    |           ^^^^^^^^^^^^^^
    |
    = help: add #![feature(uniform_paths)] to the crate attributes to enable
note: this import refers to the enum defined here
   --> src/lib.rs:163:1
    |
163 | / pub enum PatchOperation {
164 | |     /// 'add' operation
165 | |     Add(AddOperation),
166 | |     /// 'remove' operation
...   |
175 | |     Test(TestOperation),
176 | | }
    | |_^

error[E0658]: imports can only refer to extern crate names passed with `--extern` on stable channel (see issue #53130)
   --> src/lib.rs:448:9
    |
163 | / pub enum PatchOperation {
164 | |     /// 'add' operation
165 | |     Add(AddOperation),
166 | |     /// 'remove' operation
...   |
175 | |     Test(TestOperation),
176 | | }
    | |_- not an extern crate passed with `--extern`
...
448 |       use PatchOperation::*;
    |           ^^^^^^^^^^^^^^
    |
    = help: add #![feature(uniform_paths)] to the crate attributes to enable
note: this import refers to the enum defined here
   --> src/lib.rs:163:1
    |
163 | / pub enum PatchOperation {
164 | |     /// 'add' operation
165 | |     Add(AddOperation),
166 | |     /// 'remove' operation
...   |
175 | |     Test(TestOperation),
176 | | }
    | |_^
```

Adding the feature(Uniform Paths) option will fix this.

cc/ @idubrov 