### PR TITLE
👀Fixing missing escaping in diffing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,17 +2,34 @@ version: 2
 jobs:
   build:
     docker:
-      - image: xd009642/tarpaulin
+      - image: rust
     steps:
       - checkout
-      - run: rustup toolchain install stable
       - run: rustup component add clippy
-      - run: cargo +stable build
-      - run: cargo +stable test --all-targets
       - run: cargo build
+      - run: cargo test --all-targets
       - run: cargo clippy
-      - run: cargo tarpaulin --out Xml
+#      - run: cargo tarpaulin --out Xml
+#      - run:
+#          name: Uploading code coverage
+#          command: |
+#              bash <(curl -s https://codecov.io/bash)
+  # https://github.com/xd009642/tarpaulin/issues/77#issuecomment-515626043
+  coverage:
+    machine: true
+    steps:
+      - checkout
       - run:
-          name: Uploading code coverage
-          command: |
-              bash <(curl -s https://codecov.io/bash)
+          name: cargo tarpaulin (via Docker)
+          command: docker run --rm -ti -v "`pwd`:/volume" -e CODECOV_TOKEN=${CODECOV_TOKEN} --security-opt seccomp=unconfined xd009642/tarpaulin bash -c "cargo tarpaulin --release --ignore-tests -o Xml && bash <(curl -s https://codecov.io/bash)"
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - build
+      - coverage:
+          requires:
+            - build
+          filters:
+            branches:
+              only: master

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,9 +16,8 @@ nightly = []
 diff = ["treediff"]
 
 [dependencies]
-serde = "1.0.61"
-serde_derive = "1.0.61"
-serde_json = "1.0.17"
+serde = { version = "1.0.99", features = ["derive"] }
+serde_json = "1.0.40"
 
 [dependencies.treediff]
 version = "3.0.1"
@@ -27,7 +26,4 @@ optional = true
 
 [dev-dependencies]
 rand = "0.5.0"
-
-[dev-dependencies.serde_json]
-version = "1.0.17"
-features = ["preserve_order"]
+serde_json = { version = "1.0.40", features = ["preserve_order"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,11 +83,10 @@
 //! ```
 #![deny(warnings)]
 #![warn(missing_docs)]
-#[macro_use]
-extern crate serde_derive;
 #[cfg_attr(test, macro_use)]
 extern crate serde_json;
 
+use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::error::Error;
 use std::{fmt, mem};

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -1,5 +1,5 @@
-use super::super::{merge, patch, Patch};
-use serde_json;
+use crate::{merge, patch, Patch};
+use serde::Deserialize;
 use serde_json::Value;
 use std::fmt::Write;
 use std::{fs, io};


### PR DESCRIPTION
Need to escape characters `/` and `~` when generating paths for patch.