### PR TITLE
Improving errors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "json-patch"
-version = "0.2.7"
+version = "0.3.0"
 authors = ["Ivan Dubrov <dubrov.ivan@gmail.com>"]
 categories = []
 keywords = ["json", "json-patch"]
@@ -12,18 +12,15 @@ edition = "2021"
 
 [features]
 default = ["diff"]
-nightly = []
 diff = ["treediff"]
 
 [dependencies]
 serde = { version = "1.0.149", features = ["derive"] }
 serde_json = "1.0.89"
-
-[dependencies.treediff]
-version = "4.0.2"
-features = ["with-serde-json"]
-optional = true
+thiserror = "1.0.37"
+treediff = { version = "4.0.2", features = ["with-serde-json"], optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"
 serde_json = { version = "1.0.89", features = ["preserve_order"] }
+serde_yaml = "0.9.14"

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 [![crates.io](https://img.shields.io/crates/v/json-patch.svg)](https://crates.io/crates/json-patch)
 [![crates.io](https://img.shields.io/crates/d/json-patch.svg)](https://crates.io/crates/json-patch)
-[![CircleCI](https://img.shields.io/circleci/project/github/idubrov/json-patch.svg)](https://circleci.com/gh/idubrov/json-patch)
+[![Build](https://github.com/idubrov/json-patch/actions/workflows/main.yml/badge.svg)](https://github.com/idubrov/json-patch/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/idubrov/json-patch.svg)](https://codecov.io/gh/idubrov/json-patch)
 
 # json-patch

--- a/README.tpl
+++ b/README.tpl
@@ -1,6 +1,6 @@
 [![crates.io](https://img.shields.io/crates/v/json-patch.svg)](https://crates.io/crates/json-patch)
 [![crates.io](https://img.shields.io/crates/d/json-patch.svg)](https://crates.io/crates/json-patch)
-[![CircleCI](https://img.shields.io/circleci/project/github/idubrov/json-patch.svg)](https://circleci.com/gh/idubrov/json-patch)
+[![Build](https://github.com/idubrov/json-patch/actions/workflows/main.yml/badge.svg)](https://github.com/idubrov/json-patch/actions)
 [![Codecov](https://img.shields.io/codecov/c/github/idubrov/json-patch.svg)](https://codecov.io/gh/idubrov/json-patch)
 
 # {{crate}}

--- a/benches/bench.rs
+++ b/benches/bench.rs
@@ -9,7 +9,7 @@ mod generator;
 
 #[bench]
 fn bench_add_removes(b: &mut Bencher) {
-    let mut rng = rand::StdRng::from_seed(Default::default());
+    let mut rng = rand::rngs::StdRng::from_seed(Default::default());
     let params = generator::Params {
         ..Default::default()
     };
@@ -19,7 +19,7 @@ fn bench_add_removes(b: &mut Bencher) {
     b.iter(|| {
         let mut doc = doc.clone();
         let mut result = Ok(());
-        for ref p in &patches {
+        for p in &patches {
             // Patch mutable
             result = result.and_then(|_| patch(&mut doc, p));
         }

--- a/benches/generator/mod.rs
+++ b/benches/generator/mod.rs
@@ -1,6 +1,6 @@
 use json_patch::{AddOperation, Patch, PatchOperation, RemoveOperation};
 use rand::distributions::Alphanumeric;
-use rand::Rng;
+use rand::prelude::*;
 use serde_json::{Map, Value};
 use std::fmt::Write;
 
@@ -26,7 +26,10 @@ impl Default for Params {
 
 fn rand_str<R: Rng>(rng: &mut R, max_len: usize) -> String {
     let len = rng.gen::<usize>() % max_len + 1;
-    rng.sample_iter(&Alphanumeric).take(len).collect()
+    rng.sample_iter(&Alphanumeric)
+        .take(len)
+        .map(char::from)
+        .collect()
 }
 
 fn rand_literal<R: Rng>(rng: &mut R, value_size: usize) -> Value {
@@ -81,7 +84,7 @@ pub fn gen_add_remove_patches<R: Rng>(
     for _ in 0..patches {
         let mut ops = Vec::new();
         for _ in 0..operations {
-            let path = &rnd.choose(&leafs).unwrap();
+            let path = leafs.choose(rnd).unwrap();
             ops.push(PatchOperation::Remove(RemoveOperation {
                 path: (*path).clone(),
             }));

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        base: auto 
+        paths:
+          - "src"

--- a/src/diff.rs
+++ b/src/diff.rs
@@ -137,7 +137,7 @@ pub fn diff(left: &Value, right: &Value) -> super::Patch {
 
 #[cfg(test)]
 mod tests {
-    use serde_json::Value;
+    use serde_json::{json, Value};
 
     #[test]
     pub fn replace_all() {

--- a/src/tests/mod.rs
+++ b/src/tests/mod.rs
@@ -1,6 +1,8 @@
 #![allow(unused)]
 extern crate rand;
 
+use serde_json::json;
+
 mod util;
 
 use super::*;

--- a/src/tests/util.rs
+++ b/src/tests/util.rs
@@ -19,7 +19,7 @@ struct TestCase {
 fn run_case(doc: &Value, patches: &Value, merge_patch: bool) -> Result<Value, String> {
     let mut actual = doc.clone();
     if merge_patch {
-        crate::merge(&mut actual, &patches);
+        crate::merge(&mut actual, patches);
     } else {
         let patches: crate::Patch =
             serde_json::from_value(patches.clone()).map_err(|e| e.to_string())?;
@@ -35,14 +35,6 @@ fn run_case(doc: &Value, patches: &Value, merge_patch: bool) -> Result<Value, St
             })
             .map_err(|e| e.to_string())?;
     }
-    Ok(actual)
-}
-
-fn run_case_patch_unsafe(doc: &Value, patches: &Value) -> Result<Value, String> {
-    let mut actual = doc.clone();
-    let patches: crate::Patch =
-        serde_json::from_value(patches.clone()).map_err(|e| e.to_string())?;
-    crate::patch_unsafe(&mut actual, &patches).map_err(|e| e.to_string())?;
     Ok(actual)
 }
 
@@ -78,25 +70,6 @@ pub fn run_specs(path: &str) {
             Err(err) => {
                 println!("failed with '{}'", err);
                 tc.error.as_ref().expect("patch expected to succeed");
-            }
-        }
-
-        if !tc.merge {
-            match run_case_patch_unsafe(&tc.doc, &tc.patch) {
-                Ok(actual) => {
-                    if let Some(ref error) = tc.error {
-                        println!("expected to fail with '{}'", error);
-                        panic!("expected to fail, got document {:?}", actual);
-                    }
-                    println!();
-                    if let Some(ref expected) = tc.expected {
-                        assert_eq!(*expected, actual);
-                    }
-                }
-                Err(err) => {
-                    println!("failed with '{}'", err);
-                    tc.error.as_ref().expect("patch expected to succeed");
-                }
             }
         }
     }

--- a/tests/errors.yaml
+++ b/tests/errors.yaml
@@ -1,0 +1,126 @@
+- doc: &1
+    first: "Hello"
+    second: "Bye"
+    third:
+      - "first"
+      - "second"
+  patch:
+    - op: add
+      path: "/first"
+      value: "Hello!!!"
+    - op: add
+      path: "/third/00"
+      value: "value"
+  error: "Operation '/1' failed at path '/third/00': path is invalid"
+- doc: *1
+  patch:
+    - op: add
+      path: "/third/01"
+      value: "value"
+  error: "Operation '/0' failed at path '/third/01': path is invalid"
+- doc: *1
+  patch:
+    - op: add
+      path: "/third/1~1"
+      value: "value"
+  error: "Operation '/0' failed at path '/third/1~1': path is invalid"
+- doc: *1
+  patch:
+    - op: add
+      path: "/third/1.0"
+      value: "value"
+  error: "Operation '/0' failed at path '/third/1.0': path is invalid"
+- doc: *1
+  patch:
+    - op: add
+      path: "/third/1e2"
+      value: "value"
+  error: "Operation '/0' failed at path '/third/1e2': path is invalid"
+- doc: *1
+  patch:
+    - op: add
+      path: "/third/+1"
+      value: "value"
+  error: "Operation '/0' failed at path '/third/+1': path is invalid"
+- doc: *1
+  patch:
+    - op: copy
+      from: "/third/1~1"
+      path: "/fourth"
+  error: "Operation '/0' failed at path '/fourth': \"from\" path is invalid"
+- doc: *1
+  patch:
+    - op: move
+      from: "/third/1~1"
+      path: "/fourth"
+  error: "Operation '/0' failed at path '/fourth': \"from\" path is invalid"
+- doc: *1
+  patch:
+    - op: move
+      from: "/third"
+      path: "/third/0"
+  error: "Operation '/0' failed at path '/third/0': cannot move the value inside itself"
+- doc: *1
+  patch:
+    - op: add
+      path: "/invalid/add/path"
+      value: true
+  error: "Operation '/0' failed at path '/invalid/add/path': path is invalid"
+- doc: *1
+  patch:
+    - op: remove
+      path: "/invalid/remove/path"
+      value: true
+  error: "Operation '/0' failed at path '/invalid/remove/path': path is invalid"
+- doc: *1
+  patch:
+    - op: replace
+      path: "/invalid/replace/path"
+      value: true
+  error: "Operation '/0' failed at path '/invalid/replace/path': path is invalid"
+- doc: *1
+  patch:
+    - op: test
+      path: "/invalid/test/path"
+      value: true
+  error: "Operation '/0' failed at path '/invalid/test/path': path is invalid"
+- doc: *1
+  patch:
+    - op: add
+      path: "first"
+      value: true
+  error: "Operation '/0' failed at path 'first': path is invalid"
+- doc: *1
+  patch:
+    - op: replace
+      path: "first"
+      value: true
+  error: "Operation '/0' failed at path 'first': path is invalid"
+- doc: *1
+  patch:
+    - op: remove
+      path: "first"
+      value: true
+  error: "Operation '/0' failed at path 'first': path is invalid"
+- doc: *1
+  patch:
+    - op: add
+      path: "/first/add_to_primitive"
+      value: true
+  error: "Operation '/0' failed at path '/first/add_to_primitive': path is invalid"
+- doc: *1
+  patch:
+    - op: remove
+      path: "/remove_non_existent"
+  error: "Operation '/0' failed at path '/remove_non_existent': path is invalid"
+- doc: *1
+  patch:
+    - op: remove
+      path: "/first/remove_from_primitive"
+  error: "Operation '/0' failed at path '/first/remove_from_primitive': path is invalid"
+- doc: *1
+  patch:
+    - op: test
+      path: "/first"
+      value: "Other"
+  error: "Operation '/0' failed at path '/first': value did not match"

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -1,0 +1,27 @@
+use json_patch::Patch;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+#[derive(Serialize, Deserialize)]
+struct TestCase {
+    doc: Value,
+    patch: Patch,
+    error: String,
+}
+
+#[test]
+fn errors() {
+    let tests = std::fs::read_to_string("tests/errors.yaml").unwrap();
+    let cases: Vec<TestCase> = serde_yaml::from_str(&tests).unwrap();
+    for (idx, mut case) in cases.into_iter().enumerate() {
+        match json_patch::patch(&mut case.doc, &case.patch).map_err(|err| err.to_string()) {
+            Ok(_) if !case.error.is_empty() => {
+                panic!("Expected test case {} to fail with an error!", idx);
+            }
+            Err(err) if err != case.error => {
+                panic!("Expected test case {} to fail with an error:\n{}\n\nbut instead failed with an error:\n{}", idx, case.error, err);
+            }
+            _ => {}
+        }
+    }
+}


### PR DESCRIPTION
Improving returned errors (breaking change).

Removed `patch_unsafe` operation as it did not do much compared to a regular `patch` operation (breaking change).

Minor improvement to reduce allocations: only run `replace` when path actually contains "~". Note that `pointer_mut` from `serde_json` still runs `replace` operation unconditionally.