### PR TITLE
feat: implement display for patch

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,7 +79,7 @@
 #![warn(missing_docs)]
 
 use serde::{Deserialize, Serialize};
-use serde_json::{Map, Value};
+use serde_json::{Map, Value, json};
 use std::{borrow::Cow, fmt::{self, Display, Formatter}};
 use thiserror::Error;
 
@@ -128,7 +128,12 @@ pub struct AddOperation {
 
 impl Display for AddOperation {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{\"op\":\"add\",\"path\":\"{}\",\"value\":{}}}", self.path, self.value)
+        let json_value = json!({
+            "op": "add",
+            "path": self.path,
+            "value": self.value,
+        });
+        write!(f, "{}", json_value)
     }
 }
 
@@ -143,7 +148,11 @@ pub struct RemoveOperation {
 
 impl Display for RemoveOperation {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{\"op\":\"remove\",\"path\":\"{}\"}}", self.path)
+        let json_value = json!({
+            "op": "remove",
+            "path": self.path,
+        });
+        write!(f, "{}", json_value)
     }
 }
 
@@ -161,7 +170,12 @@ pub struct ReplaceOperation {
 
 impl Display for ReplaceOperation {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{\"op\":\"replace\",\"path\":\"{}\",\"value\":{}}}", self.path, self.value)
+        let json_value = json!({
+            "op": "replace",
+            "path": self.path,
+            "value": self.value,
+        });
+        write!(f, "{}", json_value)
     }
 }
 
@@ -179,7 +193,12 @@ pub struct MoveOperation {
 
 impl Display for MoveOperation {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{\"op\":\"move\",\"from\":\"{}\",\"path\":\"{}\"}}", self.from, self.path)
+        let json_value = json!({
+            "op": "move",
+            "from": self.from,
+            "path": self.path,
+        });
+        write!(f, "{}", json_value)
     }
 }
 
@@ -197,7 +216,12 @@ pub struct CopyOperation {
 
 impl Display for CopyOperation {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{\"op\":\"copy\",\"from\":\"{}\",\"path\":\"{}\"}}", self.from, self.path)
+        let json_value = json!({
+            "op": "copy",
+            "from": self.from,
+            "path": self.path,
+        });
+        write!(f, "{}", json_value)
     }
 }
 
@@ -215,7 +239,12 @@ pub struct TestOperation {
 
 impl Display for TestOperation {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{{\"op\":\"test\",\"path\":\"{}\",\"value\":{}}}", self.path, self.value)
+        let json_value = json!({
+            "op": "test",
+            "path": self.path,
+            "value": self.value,
+        });
+        write!(f, "{}", json_value)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,7 +80,8 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use std::borrow::Cow;
+use core::fmt;
+use std::{borrow::Cow, fmt::{Display, Formatter}};
 use thiserror::Error;
 
 #[cfg(feature = "diff")]
@@ -102,6 +103,18 @@ impl std::ops::Deref for Patch {
     }
 }
 
+impl Display for Patch {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        let operations = self
+            .0
+            .iter()
+            .map(|op| op.to_string())
+            .collect::<Vec<String>>()
+            .join(",");
+        write!(f, "[{}]", operations)
+    }
+}
+
 /// JSON Patch 'add' operation representation
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -114,6 +127,12 @@ pub struct AddOperation {
     pub value: Value,
 }
 
+impl Display for AddOperation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{\"op\":\"add\",\"path\":\"{}\",\"value\":{}}}", self.path, self.value)
+    }
+}
+
 /// JSON Patch 'remove' operation representation
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -121,6 +140,12 @@ pub struct RemoveOperation {
     /// JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
     /// within the target document where the operation is performed.
     pub path: String,
+}
+
+impl Display for RemoveOperation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{\"op\":\"remove\",\"path\":\"{}\"}}", self.path)
+    }
 }
 
 /// JSON Patch 'replace' operation representation
@@ -135,6 +160,12 @@ pub struct ReplaceOperation {
     pub value: Value,
 }
 
+impl Display for ReplaceOperation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{\"op\":\"replace\",\"path\":\"{}\",\"value\":{}}}", self.path, self.value)
+    }
+}
+
 /// JSON Patch 'move' operation representation
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -145,6 +176,12 @@ pub struct MoveOperation {
     /// JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
     /// within the target document where the operation is performed.
     pub path: String,
+}
+
+impl Display for MoveOperation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{\"op\":\"move\",\"from\":\"{}\",\"path\":\"{}\"}}", self.from, self.path)
+    }
 }
 
 /// JSON Patch 'copy' operation representation
@@ -159,6 +196,12 @@ pub struct CopyOperation {
     pub path: String,
 }
 
+impl Display for CopyOperation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{\"op\":\"copy\",\"from\":\"{}\",\"path\":\"{}\"}}", self.from, self.path)
+    }
+}
+
 /// JSON Patch 'test' operation representation
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "utoipa", derive(utoipa::ToSchema))]
@@ -169,6 +212,12 @@ pub struct TestOperation {
     /// Value to test against.
     #[cfg_attr(feature = "utoipa", schema(value_type = Object))]
     pub value: Value,
+}
+
+impl Display for TestOperation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{{\"op\":\"test\",\"path\":\"{}\",\"value\":{}}}", self.path, self.value)
+    }
 }
 
 /// JSON Patch single patch operation
@@ -190,6 +239,20 @@ pub enum PatchOperation {
     /// 'test' operation
     Test(TestOperation),
 }
+
+impl Display for PatchOperation {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            PatchOperation::Add(op) => op.fmt(f),
+            PatchOperation::Remove(op) => op.fmt(f),
+            PatchOperation::Replace(op) => op.fmt(f),
+            PatchOperation::Move(op) => op.fmt(f),
+            PatchOperation::Copy(op) => op.fmt(f),
+            PatchOperation::Test(op) => op.fmt(f),
+        }
+    }
+}
+
 
 /// This type represents all possible errors that can occur when applying JSON patch
 #[derive(Debug, Error)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,8 +80,7 @@
 
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
-use core::fmt;
-use std::{borrow::Cow, fmt::{Display, Formatter}};
+use std::{borrow::Cow, fmt::{self, Display, Formatter}};
 use thiserror::Error;
 
 #[cfg(feature = "diff")]

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,4 +1,4 @@
-use json_patch::{AddOperation, Patch, PatchOperation, RemoveOperation};
+use json_patch::{AddOperation, Patch, PatchOperation, RemoveOperation, TestOperation, CopyOperation, MoveOperation, ReplaceOperation};
 use serde_json::{from_str, from_value, json, Value};
 
 #[test]
@@ -51,4 +51,75 @@ fn serialize_patch() {
 
     let serialized = serde_json::to_string(&patch).unwrap();
     assert_eq!(serialized, s);
+}
+
+#[test]
+fn display_add_operation() {
+    let op = PatchOperation::Add(AddOperation {
+        path: String::from("/a/b/c"),
+        value: json!(["foo", "bar"]),
+    });
+    assert_eq!(op.to_string(), r#"{"op":"add","path":"/a/b/c","value":["foo","bar"]}"#);
+}
+
+#[test]
+fn display_remove_operation() {
+    let op = PatchOperation::Remove(RemoveOperation {
+        path: String::from("/a/b/c"),
+    });
+    assert_eq!(op.to_string(), r#"{"op":"remove","path":"/a/b/c"}"#);
+}
+
+#[test]
+fn display_replace_operation() {
+    let op = PatchOperation::Replace(ReplaceOperation {
+        path: String::from("/a/b/c"),
+        value: json!(42),
+    });
+    assert_eq!(op.to_string(), r#"{"op":"replace","path":"/a/b/c","value":42}"#);
+}
+
+#[test]
+fn display_move_operation() {
+    let op = PatchOperation::Move(MoveOperation {
+        from: String::from("/a/b/c"),
+        path: String::from("/a/b/d"),
+    });
+    assert_eq!(op.to_string(), r#"{"op":"move","from":"/a/b/c","path":"/a/b/d"}"#);
+}
+
+#[test]
+fn display_copy_operation() {
+    let op = PatchOperation::Copy(CopyOperation {
+        from: String::from("/a/b/d"),
+        path: String::from("/a/b/e"),
+    });
+    assert_eq!(op.to_string(), r#"{"op":"copy","from":"/a/b/d","path":"/a/b/e"}"#);
+}
+
+#[test]
+fn display_test_operation() {
+    let op = PatchOperation::Test(TestOperation {
+        path: String::from("/a/b/c"),
+        value: json!("foo"),
+    });
+    assert_eq!(op.to_string(), r#"{"op":"test","path":"/a/b/c","value":"foo"}"#);
+}
+
+#[test]
+fn display_patch() {
+    let patch = Patch(vec![
+        PatchOperation::Add(AddOperation {
+            path: String::from("/a/b/c"),
+            value: json!(["foo", "bar"]),
+        }),
+        PatchOperation::Remove(RemoveOperation {
+            path: String::from("/a/b/c"),
+        }),
+    ]);
+
+    assert_eq!(
+        patch.to_string(),
+        r#"[{"op":"add","path":"/a/b/c","value":["foo","bar"]},{"op":"remove","path":"/a/b/c"}]"#
+    );
 }


### PR DESCRIPTION
Awesome lib, I'd like to propose a small addition.

The `Display` trait implementation for a `Patch` allows it to be represented as a string. This string representation adheres to the JSON Patch document format, making it easily readable and compatible with other JSON Patch utilities.

This enables the full workflow of creating, storing, and applying JSON Patches.