### PR TITLE
Use `jsonptr` to represent paths

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ default = ["diff"]
 diff = ["treediff"]
 
 [dependencies]
+jsonptr = "0.4.7"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 thiserror = "1.0.40"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -147,6 +147,7 @@ impl std::ops::Deref for Patch {
 pub struct AddOperation {
     /// JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
     /// within the target document where the operation is performed.
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub path: Pointer,
     /// Value to add to the target location.
     pub value: Value,
@@ -160,6 +161,7 @@ impl_display!(AddOperation);
 pub struct RemoveOperation {
     /// JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
     /// within the target document where the operation is performed.
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub path: Pointer,
 }
 
@@ -171,6 +173,7 @@ impl_display!(RemoveOperation);
 pub struct ReplaceOperation {
     /// JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
     /// within the target document where the operation is performed.
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub path: Pointer,
     /// Value to replace with.
     pub value: Value,
@@ -184,9 +187,11 @@ impl_display!(ReplaceOperation);
 pub struct MoveOperation {
     /// JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
     /// to move value from.
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub from: Pointer,
     /// JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
     /// within the target document where the operation is performed.
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub path: Pointer,
 }
 
@@ -198,9 +203,11 @@ impl_display!(MoveOperation);
 pub struct CopyOperation {
     /// JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
     /// to copy value from.
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub from: Pointer,
     /// JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
     /// within the target document where the operation is performed.
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub path: Pointer,
 }
 
@@ -212,6 +219,7 @@ impl_display!(CopyOperation);
 pub struct TestOperation {
     /// JSON-Pointer value [RFC6901](https://tools.ietf.org/html/rfc6901) that references a location
     /// within the target document where the operation is performed.
+    #[cfg_attr(feature = "utoipa", schema(value_type = String))]
     pub path: Pointer,
     /// Value to test against.
     pub value: Value,

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -2,6 +2,7 @@ use json_patch::{
     AddOperation, CopyOperation, MoveOperation, Patch, PatchOperation, RemoveOperation,
     ReplaceOperation, TestOperation,
 };
+use jsonptr::Pointer;
 use serde_json::{from_str, from_value, json, Value};
 
 #[test]
@@ -13,11 +14,11 @@ fn parse_from_value() {
         patch,
         Patch(vec![
             PatchOperation::Add(AddOperation {
-                path: String::from("/a/b"),
+                path: Pointer::new(["a", "b"]),
                 value: Value::from(1),
             }),
             PatchOperation::Remove(RemoveOperation {
-                path: String::from("/c"),
+                path: Pointer::new(["c"]),
             }),
         ])
     );
@@ -37,11 +38,11 @@ fn parse_from_string() {
         patch,
         Patch(vec![
             PatchOperation::Add(AddOperation {
-                path: String::from("/a/b"),
+                path: Pointer::new(["a", "b"]),
                 value: Value::from(1),
             }),
             PatchOperation::Remove(RemoveOperation {
-                path: String::from("/c"),
+                path: Pointer::new(["c"]),
             }),
         ])
     );
@@ -59,7 +60,7 @@ fn serialize_patch() {
 #[test]
 fn display_add_operation() {
     let op = PatchOperation::Add(AddOperation {
-        path: String::from("/a/b/c"),
+        path: Pointer::new(["a", "b", "c"]),
         value: json!(["hello", "bye"]),
     });
     assert_eq!(
@@ -82,7 +83,7 @@ fn display_add_operation() {
 #[test]
 fn display_remove_operation() {
     let op = PatchOperation::Remove(RemoveOperation {
-        path: String::from("/a/b/c"),
+        path: Pointer::new(["a", "b", "c"]),
     });
     assert_eq!(op.to_string(), r#"{"op":"remove","path":"/a/b/c"}"#);
     assert_eq!(
@@ -97,7 +98,7 @@ fn display_remove_operation() {
 #[test]
 fn display_replace_operation() {
     let op = PatchOperation::Replace(ReplaceOperation {
-        path: String::from("/a/b/c"),
+        path: Pointer::new(["a", "b", "c"]),
         value: json!(42),
     });
     assert_eq!(
@@ -117,8 +118,8 @@ fn display_replace_operation() {
 #[test]
 fn display_move_operation() {
     let op = PatchOperation::Move(MoveOperation {
-        from: String::from("/a/b/c"),
-        path: String::from("/a/b/d"),
+        from: Pointer::new(["a", "b", "c"]),
+        path: Pointer::new(["a", "b", "d"]),
     });
     assert_eq!(
         op.to_string(),
@@ -137,8 +138,8 @@ fn display_move_operation() {
 #[test]
 fn display_copy_operation() {
     let op = PatchOperation::Copy(CopyOperation {
-        from: String::from("/a/b/d"),
-        path: String::from("/a/b/e"),
+        from: Pointer::new(["a", "b", "d"]),
+        path: Pointer::new(["a", "b", "e"]),
     });
     assert_eq!(
         op.to_string(),
@@ -157,7 +158,7 @@ fn display_copy_operation() {
 #[test]
 fn display_test_operation() {
     let op = PatchOperation::Test(TestOperation {
-        path: String::from("/a/b/c"),
+        path: Pointer::new(["a", "b", "c"]),
         value: json!("hello"),
     });
     assert_eq!(
@@ -178,11 +179,11 @@ fn display_test_operation() {
 fn display_patch() {
     let patch = Patch(vec![
         PatchOperation::Add(AddOperation {
-            path: String::from("/a/b/c"),
+            path: Pointer::new(["a", "b", "c"]),
             value: json!(["hello", "bye"]),
         }),
         PatchOperation::Remove(RemoveOperation {
-            path: String::from("/a/b/c"),
+            path: Pointer::new(["a", "b", "c"]),
         }),
     ]);
 

--- a/tests/errors.yaml
+++ b/tests/errors.yaml
@@ -11,116 +11,116 @@
     - op: add
       path: "/third/00"
       value: "value"
-  error: "Operation '/1' failed at path '/third/00': path is invalid"
+  error: "operation '/1' failed at path '/third/00': path is invalid"
 - doc: *1
   patch:
     - op: add
       path: "/third/01"
       value: "value"
-  error: "Operation '/0' failed at path '/third/01': path is invalid"
+  error: "operation '/0' failed at path '/third/01': path is invalid"
 - doc: *1
   patch:
     - op: add
       path: "/third/1~1"
       value: "value"
-  error: "Operation '/0' failed at path '/third/1~1': path is invalid"
+  error: "operation '/0' failed at path '/third/1~1': path is invalid"
 - doc: *1
   patch:
     - op: add
       path: "/third/1.0"
       value: "value"
-  error: "Operation '/0' failed at path '/third/1.0': path is invalid"
+  error: "operation '/0' failed at path '/third/1.0': path is invalid"
 - doc: *1
   patch:
     - op: add
       path: "/third/1e2"
       value: "value"
-  error: "Operation '/0' failed at path '/third/1e2': path is invalid"
+  error: "operation '/0' failed at path '/third/1e2': path is invalid"
 - doc: *1
   patch:
     - op: add
       path: "/third/+1"
       value: "value"
-  error: "Operation '/0' failed at path '/third/+1': path is invalid"
+  error: "operation '/0' failed at path '/third/+1': path is invalid"
 - doc: *1
   patch:
     - op: copy
       from: "/third/1~1"
       path: "/fourth"
-  error: "Operation '/0' failed at path '/fourth': \"from\" path is invalid"
+  error: "operation '/0' failed at path '/fourth': \"from\" path is invalid"
 - doc: *1
   patch:
     - op: move
       from: "/third/1~1"
       path: "/fourth"
-  error: "Operation '/0' failed at path '/fourth': \"from\" path is invalid"
+  error: "operation '/0' failed at path '/fourth': \"from\" path is invalid"
 - doc: *1
   patch:
     - op: move
       from: "/third"
       path: "/third/0"
-  error: "Operation '/0' failed at path '/third/0': cannot move the value inside itself"
+  error: "operation '/0' failed at path '/third/0': cannot move the value inside itself"
 - doc: *1
   patch:
     - op: add
       path: "/invalid/add/path"
       value: true
-  error: "Operation '/0' failed at path '/invalid/add/path': path is invalid"
+  error: "operation '/0' failed at path '/invalid/add/path': path is invalid"
 - doc: *1
   patch:
     - op: remove
       path: "/invalid/remove/path"
       value: true
-  error: "Operation '/0' failed at path '/invalid/remove/path': path is invalid"
+  error: "operation '/0' failed at path '/invalid/remove/path': path is invalid"
 - doc: *1
   patch:
     - op: replace
       path: "/invalid/replace/path"
       value: true
-  error: "Operation '/0' failed at path '/invalid/replace/path': path is invalid"
+  error: "operation '/0' failed at path '/invalid/replace/path': path is invalid"
 - doc: *1
   patch:
     - op: test
       path: "/invalid/test/path"
       value: true
-  error: "Operation '/0' failed at path '/invalid/test/path': path is invalid"
+  error: "operation '/0' failed at path '/invalid/test/path': path is invalid"
 - doc: *1
   patch:
     - op: add
       path: "first"
       value: true
-  error: "Operation '/0' failed at path 'first': path is invalid"
+  error: "json pointer \"first\" is malformed due to missing starting slash"
 - doc: *1
   patch:
     - op: replace
       path: "first"
       value: true
-  error: "Operation '/0' failed at path 'first': path is invalid"
+  error: "json pointer \"first\" is malformed due to missing starting slash"
 - doc: *1
   patch:
     - op: remove
       path: "first"
       value: true
-  error: "Operation '/0' failed at path 'first': path is invalid"
+  error: "json pointer \"first\" is malformed due to missing starting slash"
 - doc: *1
   patch:
     - op: add
       path: "/first/add_to_primitive"
       value: true
-  error: "Operation '/0' failed at path '/first/add_to_primitive': path is invalid"
+  error: "operation '/0' failed at path '/first/add_to_primitive': path is invalid"
 - doc: *1
   patch:
     - op: remove
       path: "/remove_non_existent"
-  error: "Operation '/0' failed at path '/remove_non_existent': path is invalid"
+  error: "operation '/0' failed at path '/remove_non_existent': path is invalid"
 - doc: *1
   patch:
     - op: remove
       path: "/first/remove_from_primitive"
-  error: "Operation '/0' failed at path '/first/remove_from_primitive': path is invalid"
+  error: "operation '/0' failed at path '/first/remove_from_primitive': path is invalid"
 - doc: *1
   patch:
     - op: test
       path: "/first"
       value: "Other"
-  error: "Operation '/0' failed at path '/first': value did not match"
+  error: "operation '/0' failed at path '/first': value did not match"


### PR DESCRIPTION
RFC 6902 references [RFC 6901](https://datatracker.ietf.org/doc/html/rfc6901) where it chooses to define the paths in the patch operations as JSON Pointers. JSON Pointers can be encoded as strings, but they are conceptually a separate type, with very particular set of invariants that have to be maintained. This motivates defining a separate Rust type to represent them, as was done in the [`jsonptr`](https://github.com/chanced/jsonptr) crate, so that manipulations over these paths can be performed safely and with reusable code.

While use of `String`s is sufficient to implement the required JSON Patch logic in this crate with minimal boilerplate, it makes it inconvenient for crate users to manipulate the patch operations outside of the `diff` and `merge` APIs. For example, a manual implementation of `merge` for a type other than a `serde_json::Value` would have to either implement its own string manipulation utilities for extracting tokens from the paths for traversal, or convert to a `jsonptr::Pointer`, which requires a clone. The reverse may also be required if the user crate intends to produce its own JSON Patches.

By embracing the `jsonptr::Pointer` type as the representation for the operation paths in this crate, not only we make things simpler and more efficient at the consumer side, we also avoid implementing some error-prone logic in this crate, as it can take advantage of the useful APIs provided by the `jsonptr` crate. The resulting code ends up being simpler, more elegant and easier to reason about on both sides.

In short, why reinvent the wheel? If there's a perfectly good representation for JSON Pointers in the Rust open-source ecosystem, may as well converge on it.

# Side changes
* Adding a `PatchOperation::path` method here for user convenience, since every operation has this field and it's useful for directing the operation to its appropriate location without need for matching explicitly on the operation variant.
* Changed the error message of PatchError to start with a lowercase character (as [is conventional in std](https://doc.rust-lang.org/std/error/trait.Error.html), and to match the `jsonptr` messages),