### PR TITLE
take better advantage of jsonptr

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,8 @@ default = ["diff"]
 diff = []
 
 [dependencies]
-jsonptr = "0.6.0"
+# jsonptr = "0.6.0"
+jsonptr = { git = "https://github.com/asmello/jsonptr", branch = "main" }
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 thiserror = "1.0.40"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,7 @@ default = ["diff"]
 diff = []
 
 [dependencies]
-# jsonptr = "0.6.0"
-jsonptr = { git = "https://github.com/asmello/jsonptr", branch = "main" }
+jsonptr = "0.7.1"
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 thiserror = "1.0.40"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,7 @@ pub use self::diff::diff;
 
 struct WriteAdapter<'a>(&'a mut dyn fmt::Write);
 
-impl<'a> std::io::Write for WriteAdapter<'a> {
+impl std::io::Write for WriteAdapter<'_> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, std::io::Error> {
         let s = std::str::from_utf8(buf).unwrap();
         self.0

--- a/tests/errors.yaml
+++ b/tests/errors.yaml
@@ -47,13 +47,13 @@
     - op: copy
       from: "/third/1~1"
       path: "/fourth"
-  error: "operation '/0' failed at path '/fourth': \"from\" path is invalid"
+  error: 'operation ''/0'' failed at path ''/fourth'': "from" path is invalid'
 - doc: *1
   patch:
     - op: move
       from: "/third/1~1"
       path: "/fourth"
-  error: "operation '/0' failed at path '/fourth': \"from\" path is invalid"
+  error: 'operation ''/0'' failed at path ''/fourth'': "from" path is invalid'
 - doc: *1
   patch:
     - op: move
@@ -89,19 +89,19 @@
     - op: add
       path: "first"
       value: true
-  error: "json pointer is malformed as it does not start with a backslash ('/')"
+  error: "json pointer failed to parse; does not start with a slash ('/') and is not empty"
 - doc: *1
   patch:
     - op: replace
       path: "first"
       value: true
-  error: "json pointer is malformed as it does not start with a backslash ('/')"
+  error: "json pointer failed to parse; does not start with a slash ('/') and is not empty"
 - doc: *1
   patch:
     - op: remove
       path: "first"
       value: true
-  error: "json pointer is malformed as it does not start with a backslash ('/')"
+  error: "json pointer failed to parse; does not start with a slash ('/') and is not empty"
 - doc: *1
   patch:
     - op: add

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -72,12 +72,11 @@ fn run_patch_test_case(tc: &PatchTestCase, kind: PatchKind) -> Result<Value, Str
     // Patch and verify that in case of error document wasn't changed
     let patch: Patch = serde_json::from_value(tc.patch.clone()).map_err(|err| err.to_string())?;
     json_patch::patch(&mut actual, &patch)
-        .map_err(|e| {
+        .inspect_err(|_| {
             assert_eq!(
                 tc.doc, actual,
                 "no changes should be made to the original document"
             );
-            e
         })
         .map_err(|err| err.to_string())?;
     Ok(actual)


### PR DESCRIPTION
`jsonptr` has been upgraded with more specialised utility functions that this crate reimplements. Let's delegate low-level string manipulation to the source crate and take advantage of the nifty new zero-copy APIs.