### PR TITLE
re-export jsonptr

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -84,6 +84,10 @@ use serde_json::{Map, Value};
 use std::fmt::{self, Display, Formatter};
 use thiserror::Error;
 
+// So users can instance `jsonptr::PointerBuf` and others without
+// having to explicitly match our `jsonptr` version.
+pub use jsonptr;
+
 #[cfg(feature = "diff")]
 mod diff;
 


### PR DESCRIPTION
Otherwise it's a requirement to add a side dependency of `jsonptr`​ explicitly in order to create `jsonptr::PointerBuf​` instances, as required for normal usage of `json-patch​`.