### PR TITLE
Bump schemars to 1.0.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ diff = []
 
 [dependencies]
 jsonptr = "0.7.1"
-schemars = { version = "0.8", optional = true }
+schemars = { version = "1.0.4", optional = true }
 serde = { version = "1.0.159", features = ["derive"] }
 serde_json = "1.0.95"
 thiserror = "1.0.40"
@@ -25,7 +25,7 @@ utoipa = { version = "4.0", optional = true }
 [dev-dependencies]
 expectorate = "1.0"
 rand = "0.8.5"
-schemars = "0.8.22"
+schemars = "1.0.4"
 serde_json = { version = "1.0.95", features = ["preserve_order"] }
 serde_yaml = "0.9.19"
 utoipa = { version = "4.0", features = ["debug"] }


### PR DESCRIPTION
Currently we depend on the pre-1.x version.