### PR TITLE
Exclude development scripts from published package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ repository = "https://github.com/idubrov/json-patch"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 edition = "2021"
+include = ["Cargo.toml", "README.md", "LICENSE-MIT", "LICENSE-APACHE", "src/**/*.rs"]
 
 [features]
 default = ["diff"]


### PR DESCRIPTION
During a dependency review we noticed that the json-patch crate includes various development scripts. These development scripts shouldn't be there as they might, at some point become problematic. As of now they prevent any downstream user from enabling the `[bans.build.interpreted]` option of cargo deny.

I opted for using an explicit include list instead of an exclude list to prevent these files from being included in the published packages to make sure that everything that's included is an conscious choice.