### PR TITLE
replace serde_yaml 0.9 to yaml_serde 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,5 +28,5 @@ expectorate = "1.0"
 rand = "0.8.5"
 schemars = "1.0.4"
 serde_json = { version = "1.0.95", features = ["preserve_order"] }
-serde_yaml = "0.9.19"
+yaml_serde = "0.10.3"
 utoipa = { version = "5", features = ["debug"] }

--- a/tests/suite.rs
+++ b/tests/suite.rs
@@ -86,7 +86,7 @@ fn run_specs(path: &str, errors: Errors, kind: PatchKind) {
     let cases = std::fs::read_to_string(path).unwrap();
     let is_yaml = path.ends_with(".yaml") || path.ends_with(".yml");
     let cases: Vec<PatchTestCase> = if is_yaml {
-        serde_yaml::from_str(&cases).unwrap()
+        yaml_serde::from_str(&cases).unwrap()
     } else {
         serde_json::from_str(&cases).unwrap()
     };


### PR DESCRIPTION
Now yaml organization forked serde_yaml and officially supports this new yaml_serde.

https://yaml.org/ have link to
https://yaml.com/ on main page link to
https://yaml.com/projects/yaml-serde/
and then it links to https://github.com/yaml/yaml-serde
which is now part of the yaml project https://github.com/yaml/
So we should use this new crate https://crates.io/crates/yaml_serde